### PR TITLE
Add 'Babel!=2.4.0,>=2.3.4' to clients-requirements.txt

### DIFF
--- a/clients-requirements.txt
+++ b/clients-requirements.txt
@@ -8,3 +8,4 @@ bzr+lp:mojo#egg=mojo
 python-openstackclient
 python-neutronclient
 python-swiftclient
+babel!=2.4.0,>=2.3.4


### PR DESCRIPTION
New version of oslo.i18n has babel requirement of 'Babel!=2.4.0,>=2.3.4' - 2.4.0 is latest and is installed by default.