### PR TITLE
delete_crm_leader.py needs disto-info

### DIFF
--- a/clients-requirements.txt
+++ b/clients-requirements.txt
@@ -5,6 +5,7 @@ jinja2>=2.8  # Version in Xenial
 python-cinderclient>=1.0.0  # From Mojo requirements
 bzr+lp:codetree#egg=codetree
 bzr+lp:mojo#egg=mojo
+distro-info
 python-openstackclient
 python-neutronclient
 python-swiftclient


### PR DESCRIPTION
delete_crm_leader.py from the OpenStack mojo specs needs the
disto-info module.