### PR TITLE
Update tox.ini to stop using unverified package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 passenv = HOME TERM
 install_command =
-  pip install --allow-unverified python-apt {opts} {packages}
+  pip install {opts} {packages}
 
 [testenv:clients]
 basepython = python2.7


### PR DESCRIPTION
As of pip 10.0, --allow-unverified is not permitted.

The usage of that in this repo was accidental and not actually required.