### PR TITLE
Python3 clients

### DIFF
--- a/py3-clients-requirements.txt
+++ b/py3-clients-requirements.txt
@@ -1,0 +1,30 @@
+# Zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+
+# Mojo
+juju-deployer
+websocket-client!=0.44.0  # https://bugs.launchpad.net/mojo/+bug/1713871
+argcomplete>=0.8.1  # Version in Xenial
+jinja2>=2.8  # Version in Xenial
+setuptools==36.4.0  # For Mojo
+bzr+lp:codetree#egg=codetree
+# bzr+lp:mojo#egg=mojo # disabled for our working branch on py3
+bzr+lp:~ost-maintainers/mojo/py3#egg=mojo
+distro-info
+dnspython
+babel!=2.4.0,>=2.3.4
+paramiko  # For mojo_os_utils
+
+# OpenStack
+python-openstackclient>=3.14.0
+aodhclient
+python-designateclient
+python-ceilometerclient
+python-cinderclient
+python-glanceclient
+python-heatclient
+python-keystoneclient
+python-neutronclient
+python-novaclient
+python-swiftclient
+

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,9 @@ basepython = python2.7
 deps = -r{toxinidir}/clients-requirements.txt
 commands = mojo --version
            openstack --version
+
+[testenv:py3-clients]
+basepython = python3
+deps = -r{toxinidir}/py3-clients-requirements.txt
+commands = mojo --version
+           openstack --version


### PR DESCRIPTION
As a part of moving mojo to use zaza we need to use python3 for the
clients venv.

This change adds a new tox target for the python3 clents.