### PR TITLE
Freeze cmd2 library temporarilly

### DIFF
--- a/clients-requirements.txt
+++ b/clients-requirements.txt
@@ -7,6 +7,7 @@ setuptools==36.4.0  # For Mojo
 bzr+lp:codetree#egg=codetree
 # bzr+lp:mojo#egg=mojo # disabled for our working branch on py3
 bzr+lp:~ost-maintainers/mojo/py3#egg=mojo
+cmd2!=0.8.3,<0.9.0  # MIT
 distro-info
 dnspython
 aodhclient

--- a/py3-clients-requirements.txt
+++ b/py3-clients-requirements.txt
@@ -10,6 +10,7 @@ setuptools==36.4.0  # For Mojo
 bzr+lp:codetree#egg=codetree
 # bzr+lp:mojo#egg=mojo # disabled for our working branch on py3
 bzr+lp:~ost-maintainers/mojo/py3#egg=mojo
+cmd2!=0.8.3  # MIT
 distro-info
 dnspython
 babel!=2.4.0,>=2.3.4


### PR DESCRIPTION
Root of the issue is a release blunder by a upstream dependency:
https://github.com/python-cmd2/cmd2/issues/421

Upstream has made the same change to global requirements here:
https://review.openstack.org/#/c/570811

We can remove this again as soon as changes propagate out to all
dependencies.