### PR TITLE
Switch to using python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,6 @@ install_command =
   pip install {opts} {packages}
 
 [testenv:clients]
-basepython = python2.7
-deps = -r{toxinidir}/clients-requirements.txt
-commands = mojo --version
-           openstack --version
-
-[testenv:py3-clients]
 basepython = python3
 deps = -r{toxinidir}/py3-clients-requirements.txt
 commands = mojo --version


### PR DESCRIPTION
Switch the clients target to the former py3-clients target. This will
enable testing with python3 tools like zaza and libjuju.