### PR TITLE
Add `juju-crashdump` as a dependency

### DIFF
--- a/py3-clients-requirements.txt
+++ b/py3-clients-requirements.txt
@@ -1,6 +1,9 @@
 # Zaza
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
 
+# Juju crashdump
+git+https://github.com/juju/juju-crashdump.git#egg=juju-crashdump
+
 # Mojo
 juju-deployer
 websocket-client!=0.44.0  # https://bugs.launchpad.net/mojo/+bug/1713871


### PR DESCRIPTION
Preparing for next generation log collection for Zaza models