### PR TITLE
Add a `juju show-controller` to the "should we bootstrap" check

### DIFF
--- a/juju-openstack-controller-example.sh
+++ b/juju-openstack-controller-example.sh
@@ -35,7 +35,7 @@ grep ${CLOUD_NAME}-keystone juju-configs/clouds.yaml && sed -e "s#http://${CLOUD
 
 juju add-cloud --replace $CLOUD_NAME juju-configs/clouds.yaml
 
-juju switch $CONTROLLER_NAME ||\
+juju switch $CONTROLLER_NAME && juju show-controller $CONTROLLER_NAME ||\
     time juju bootstrap --bootstrap-constraints "$BOOTSTRAP_CONSTRAINTS" \
                         --constraints "$MODEL_CONSTRAINTS" \
                         --auto-upgrade=false \

--- a/juju-openstack-controller-example.sh
+++ b/juju-openstack-controller-example.sh
@@ -35,7 +35,7 @@ grep ${CLOUD_NAME}-keystone juju-configs/clouds.yaml && sed -e "s#http://${CLOUD
 
 juju add-cloud --replace $CLOUD_NAME juju-configs/clouds.yaml
 
-juju switch $CONTROLLER_NAME && juju show-controller $CONTROLLER_NAME ||\
+juju switch $CONTROLLER_NAME && timeout 15 juju show-controller $CONTROLLER_NAME ||\
     time juju bootstrap --bootstrap-constraints "$BOOTSTRAP_CONSTRAINTS" \
                         --constraints "$MODEL_CONSTRAINTS" \
                         --auto-upgrade=false \


### PR DESCRIPTION
`juju switch` isn't enough to verify the working presence of a controller.
In the case where a controller has a problem, we probably want to try
to bootstrap even if we have the configuration for a controller in our
local cache