### PR TITLE
Use force & no-wait to remove zaza models with CMRs

### DIFF
--- a/juju-destroy-zaza-models.sh
+++ b/juju-destroy-zaza-models.sh
@@ -4,6 +4,7 @@
 if juju controllers &> /dev/null; then
     zaza_models="$(juju models --format yaml | awk '/short-name: zaza-/{ print $2 }')"
     for MODEL_NAME in $zaza_models; do
-        juju destroy-model -y --destroy-storage ${MODEL_NAME}
+        # Use --force  --no-wait to remove zaza models that have CMRs
+        juju destroy-model -y --destroy-storage --force --no-wait ${MODEL_NAME}
     done
 fi


### PR DESCRIPTION
ubuntu-openstack-ci uses juju-destroy-zaza-models.sh to remove zaza
models. New tests are being introduced with CMRs, to simplify the
removal of models with CMRs use --force and --no-wait.