### PR TITLE
Revert change to force delete models

### DIFF
--- a/juju-destroy-zaza-models.sh
+++ b/juju-destroy-zaza-models.sh
@@ -4,7 +4,6 @@
 if juju controllers &> /dev/null; then
     zaza_models="$(juju models --format yaml | awk '/short-name: zaza-/{ print $2 }')"
     for MODEL_NAME in $zaza_models; do
-        # Use --force  --no-wait to remove zaza models that have CMRs
-        juju destroy-model -y --destroy-storage --force --no-wait ${MODEL_NAME}
+        juju destroy-model -y --destroy-storage ${MODEL_NAME}
     done
 fi


### PR DESCRIPTION
The force delete is leaving models hanging around. Because we use
vips for many tests this can lead to duplicate vips within the
same tenant network. This revert breaks the swift CMR tests which is the
lesser of two evils.