### PR TITLE
Disable mounting of /dev/vdb in serverstack model instances

### DIFF
--- a/juju-configs/model-default-serverstack.yaml
+++ b/juju-configs/model-default-serverstack.yaml
@@ -9,3 +9,7 @@ transmit-vendor-metrics: false
 enable-os-upgrade: false
 automatically-retry-hooks: false
 use-default-secgroup: true
+# disable mounting of /dev/vdb so that all block devs are clean
+cloudinit-userdata: |
+  mounts:
+  - [ vdb ]


### PR DESCRIPTION
This patch uses cloudinit-userdata to stop the instance mounting
/dev/vdb.  This is useful on cosmic+ due to an error [1] where if the
instance mounts /dev/vdb then lxc-fs "holds" the mount despite the charm
performing an umount.  This means that the device can't be used for
anything else and the cinder charm, in particularly, will fail to pass
its tests.

[1] Bug #1842751 -  [disco] [eoan] After unmount, cannot open /dev/vdb:
                    Device or resource busy