### PR TITLE
Revert "Disable mounting of /dev/vdb in serverstack model instances"

### DIFF
--- a/juju-configs/model-default-serverstack.yaml
+++ b/juju-configs/model-default-serverstack.yaml
@@ -9,7 +9,3 @@ transmit-vendor-metrics: false
 enable-os-upgrade: false
 automatically-retry-hooks: false
 use-default-secgroup: true
-# disable mounting of /dev/vdb so that all block devs are clean
-cloudinit-userdata: |
-  mounts:
-  - [ vdb ]


### PR DESCRIPTION
Reverts openstack-charmers/charm-test-infra#42

This causes breakage where disk ordering is undefined - so any
charm test that uses ceph-osd is currently broken