### PR TITLE
Fix mojo.contain.InvalidUbuntuSeries error

### DIFF
--- a/clients-requirements.txt
+++ b/clients-requirements.txt
@@ -5,8 +5,7 @@ jinja2>=2.8  # Version in Xenial
 python-cinderclient>=1.0.0  # From Mojo requirements
 setuptools==36.4.0  # For Mojo
 bzr+lp:codetree#egg=codetree
-# bzr+lp:mojo#egg=mojo # disabled for our working branch on py3
-bzr+lp:~ost-maintainers/mojo/py3#egg=mojo
+bzr+lp:mojo#egg=mojo
 cmd2!=0.8.3,<0.9.0  # MIT
 distro-info
 dnspython

--- a/py3-clients-requirements.txt
+++ b/py3-clients-requirements.txt
@@ -13,8 +13,7 @@ argcomplete>=0.8.1  # Version in Xenial
 jinja2>=2.8  # Version in Xenial
 setuptools==36.4.0  # For Mojo
 bzr+lp:codetree#egg=codetree
-# bzr+lp:mojo#egg=mojo # disabled for our working branch on py3
-bzr+lp:~ost-maintainers/mojo/py3#egg=mojo
+bzr+lp:mojo#egg=mojo
 cmd2!=0.8.3  # MIT
 distro-info
 dnspython


### PR DESCRIPTION
Our mojo fork lacks this line [0], which leads to [1]
mojo.contain.InvalidUbuntuSeries: focal is not a valid Ubuntu series

Upstream mojo now also supports Python 3 so we can stop using our fork.

0: https://bazaar.launchpad.net/~mojo-maintainers/mojo/trunk/view/head:/mojo/contain.py#L48
1: http://osci:8080/view/MojoMatrix/job/mojo_runner/22571/console

Validated locally with

```
export MOJO_SPEC=specs/dev/magpie
export U_OS=focal-distro
export MOJO_OPENSTACK_SPECS_REPO=git://github.com/openstack-charmers/openstack-mojo-specs.git
export MOJO_OPENSTACK_SPECS_BRANCH=master
export CTI_REPO=https://github.com/AurelienLourot/charm-test-infra
export CTI_REPO_BRANCH=focal
export OSCI_ROOT=$(pwd)
mkdir workspace
export WORKSPACE=$(pwd)/workspace
export MODEL_NAME=lourot-mojo
juju add-model $MODEL_NAME
./run/job-parts/build_mojo_runner.sh
```