### PR TITLE
Use force to destroy models juju >= 2.8

### DIFF
--- a/juju-destroy-model-example.sh
+++ b/juju-destroy-model-example.sh
@@ -18,6 +18,8 @@ set -ux
 : ${CONTROLLER_NAME:="${OS_PROJECT_NAME}-${CLOUD_NAME}"}
 : ${MODEL_NAME:="${OS_PROJECT_NAME:0:12}"}
 
+# Use force due to juju 2.8 stopping destroy-model on hook errors
+# 5 Minute timeout to allow juju to attempt to destroy openstack resources
 juju controllers &> /dev/null &&\
     juju show-model ${CONTROLLER_NAME}:${MODEL_NAME} &> /dev/null &&\
-        juju destroy-model --destroy-storage $1 ${CONTROLLER_NAME}:${MODEL_NAME} ||:
+        juju destroy-model --destroy-storage $1 ${CONTROLLER_NAME}:${MODEL_NAME} --force -t 300 ||:

--- a/juju-destroy-model-example.sh
+++ b/juju-destroy-model-example.sh
@@ -22,4 +22,4 @@ set -ux
 # 5 Minute timeout to allow juju to attempt to destroy openstack resources
 juju controllers &> /dev/null &&\
     juju show-model ${CONTROLLER_NAME}:${MODEL_NAME} &> /dev/null &&\
-        juju destroy-model --destroy-storage $1 ${CONTROLLER_NAME}:${MODEL_NAME} --force -t 300 ||:
+        juju destroy-model --destroy-storage $1 ${CONTROLLER_NAME}:${MODEL_NAME} --force -t 300s ||:

--- a/juju-destroy-zaza-models.sh
+++ b/juju-destroy-zaza-models.sh
@@ -4,6 +4,8 @@
 if juju controllers &> /dev/null; then
     zaza_models="$(juju models --format yaml | awk '/short-name: zaza-/{ print $2 }')"
     for MODEL_NAME in $zaza_models; do
-        juju destroy-model -y --destroy-storage ${MODEL_NAME}
+        # Use force due to juju 2.8 stopping destroy-model on hook errors
+        # 5 Minute timeout to allow juju to attempt to destroy openstack resources
+        juju destroy-model -y --destroy-storage ${MODEL_NAME} --force -t 300
     done
 fi

--- a/juju-destroy-zaza-models.sh
+++ b/juju-destroy-zaza-models.sh
@@ -6,6 +6,6 @@ if juju controllers &> /dev/null; then
     for MODEL_NAME in $zaza_models; do
         # Use force due to juju 2.8 stopping destroy-model on hook errors
         # 5 Minute timeout to allow juju to attempt to destroy openstack resources
-        juju destroy-model -y --destroy-storage ${MODEL_NAME} --force -t 300
+        juju destroy-model -y --destroy-storage ${MODEL_NAME} --force -t 300s
     done
 fi


### PR DESCRIPTION
Juju 2.8 stops the destroy-model process when a charm goes into hook
error. Hook errors on destroy are highly likely, thus hanging the
destroy-model process.

Use --force with a 5 minute timeout to let juju attempt to destroy
openstack resources but eventually complete the destroy-model process.