### PR TITLE
Fix juju crashdump name

### DIFF
--- a/py3-clients-requirements.txt
+++ b/py3-clients-requirements.txt
@@ -4,7 +4,7 @@ git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.open
 
 # Juju crashdump
 # pin commit to work around https://github.com/juju/juju-crashdump/issues/34
-git+https://github.com/juju/juju-crashdump.git@dba9ff0e6d71d25d37d9011d032d5fcc1af21c5c#egg=juju-crashdump
+git+https://github.com/juju/juju-crashdump.git@dba9ff0e6d71d25d37d9011d032d5fcc1af21c5c#egg=jujucrashdump
 
 # Mojo
 juju-deployer


### PR DESCRIPTION
The metadata for juju crashdump shows it is called
jujucrashdump not juju-crashdump. This is now causing
install issues, probably down to pips new resolved

*1 https://github.com/juju/juju-crashdump/blob/master/setup.py#L6
*2 https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_full/openstack/charm-barbican-vault/764470/1/7539/consoleText.test_charm_func_full_10599.txt