### PR TITLE
Fix codetree name

### DIFF
--- a/py3-clients-requirements.txt
+++ b/py3-clients-requirements.txt
@@ -12,7 +12,7 @@ websocket-client!=0.44.0  # https://bugs.launchpad.net/mojo/+bug/1713871
 argcomplete>=0.8.1  # Version in Xenial
 jinja2>=2.8  # Version in Xenial
 setuptools==36.4.0  # For Mojo
-bzr+lp:codetree#egg=codetree
+bzr+lp:codetree#egg=python-codetree
 
 # disabled because of a bug because of which whitelisted states aren't taken
 # into account when waiting for the model to become ready:


### PR DESCRIPTION
The metadata for codetree shows it is called
python-codetree not codetree. This is now causing
install issues, probably down to pips new resolved

*1 https://bazaar.launchpad.net/~codetree-maintainers/codetree/trunk/view/head:/setup.py#L21
*2 https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_full/openstack/charm-barbican-vault/764470/1/7542/consoleText.test_charm_func_full_10600.txt