### PR TITLE
Fix SyntaxError with Python 3.5

### DIFF
--- a/py3-clients-requirements.txt
+++ b/py3-clients-requirements.txt
@@ -57,5 +57,9 @@ importlib-resources<3.0.0; python_version < '3.6'
 # Missing dependency of python-openstackclient:
 dogpile.cache<1.0.0; python_version < '3.6'
 
+# Dependency of python-openstackclient. Newer versions dropped Python 3.5
+# support:
+openstacksdk<=0.31.1; python_version < '3.6'
+
 # Dependency of python-glanceclient. Newer versions dropped Python 3.5 support:
 oslo.utils<=3.41.0; python_version < '3.6'


### PR DESCRIPTION
Validated on a pristine Xenial VM with

```
tox -e clients
```

Without this change we get

```
14:28:23 clients installdeps: -r/var/lib/jenkins/tools/0/charm-test-infra/py3-clients-requirements.txt
14:30:22 clients installed: You are using pip version 8.1.1, however version 20.3.1 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,aodhclient==1.2.0,appdirs==1.4.4,argcomplete==1.12.2,async-generator==1.10,attrs==20.3.0,Babel==2.9.0,bcrypt==3.2.0,boto3==1.16.31,botocore==1.19.31,certifi==2020.12.5,cffi==1.14.4,chardet==3.0.4,cliff==3.5.0,cmd2==1.4.0,colorama==0.4.4,cryptography==3.2.1,debtcollector==2.2.0,decorator==4.4.2,dnspython==2.0.0,dogpile.cache==0.9.2,futurist==1.10.0,gnocchiclient==7.0.7,hvac==0.6.4,idna==2.10,importlib-metadata==2.1.1,importlib-resources==2.0.1,ipaddress==1.0.23,iso8601==0.1.13,Jinja2==2.11.2,jmespath==0.10.0,jsonpatch==1.28,jsonpointer==2.0,jsonschema==3.2.0,juju==2.8.4,juju-deployer==0.11.0,juju-wait==2.8.4,jujubundlelib==0.5.6,jujuclient==0.54.0,jujucrashdump==0.0.0,keystoneauth1==4.3.0,lxml==4.6.2,macaroonbakery==1.3.1,MarkupSafe==1.1.1,mojo==0.4.5,monotonic==1.5,msgpack==1.0.0,munch==2.5.0,mypy-extensions==0.4.3,ndg-httpsclient==0.3.3,netaddr==0.8.0,netifaces==0.10.9,openstacksdk==0.52.0,os-client-config==2.1.0,os-service-types==1.7.0,osc-lib==2.3.0,oslo.config==6.11.3,oslo.context==3.1.1,oslo.i18n==5.0.1,oslo.log==4.4.0,oslo.serialization==4.0.1,oslo.utils==3.41.0,paramiko==2.7.2,pbr==5.5.1,pika==1.1.0,pkg-resources==0.0.0,prettytable==0.7.2,protobuf==3.14.0,pyasn1==0.4.8,pycparser==2.20,pyinotify==0.9.6,pylxd==2.0.7,pymacaroons==0.13.0,PyNaCl==1.4.0,pyOpenSSL==20.0.0,pyparsing==2.4.7,pyperclip==1.8.1,pyRFC3339==1.1,pyrsistent==0.17.3,python-barbicanclient==4.10.0,python-ceilometerclient==2.9.0,python-cinderclient==4.2.2,python-codetree==1.2.0,python-dateutil==2.8.1,python-designateclient==2.12.0,python-glanceclient==2.16.0,python-heatclient==1.17.1,python-ironicclient==4.4.0,python-keystoneclient==3.19.1,python-manilaclient==1.29.0,python-neutronclient==6.12.1,python-novaclient==13.0.2,python-octaviaclient==1.10.1,python-openstackclient==3.18.1,python-swiftclient==3.8.0,pytz==2020.4,PyYAML==5.3.1,requests==2.25.0,requests-unixsocket==0.2.0,requestsexceptions==1.4.0,rfc3986==1.4.0,s3transfer==0.3.3,simplejson==3.17.2,six==1.15.0,stevedore==3.3.0,tenacity==6.2.0,theblues==0.5.2,toposort==1.5,typing-extensions==3.7.4.3,typing-inspect==0.6.0,ujson==4.0.1,urllib3==1.26.2,warlock==1.3.3,wcwidth==0.2.5,websocket-client==0.57.0,websocket-client-py3==0.15.0,websockets==7.0,wrapt==1.12.1,ws4py==0.5.1,zaza==0.0.2.dev1,zaza.openstack==0.0.1.dev1,zipp==3.4.0
14:30:22 clients run-test-pre: PYTHONHASHSEED='0'
14:30:22 clients run-test: commands[0] | mojo --version
14:30:24 /var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/OpenSSL/crypto.py:14: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
14:30:24   from cryptography import utils, x509
14:30:24 0.4.5
14:30:24 clients run-test: commands[1] | openstack --version
14:30:24 Traceback (most recent call last):
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/bin/openstack", line 7, in <module>
14:30:24     from openstackclient.shell import main
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/openstackclient/shell.py", line 23, in <module>
14:30:24     from osc_lib import shell
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/osc_lib/shell.py", line 32, in <module>
14:30:24     from osc_lib.cli import client_config as cloud_config
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/osc_lib/cli/client_config.py", line 18, in <module>
14:30:24     from openstack.config import exceptions as sdk_exceptions
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/openstack/__init__.py", line 18, in <module>
14:30:24     import openstack.connection
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/openstack/connection.py", line 194, in <module>
14:30:24     from openstack import _services_mixin
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/openstack/_services_mixin.py", line 12, in <module>
14:30:24     from openstack.image import image_service
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/openstack/image/image_service.py", line 13, in <module>
14:30:24     from openstack.image.v1 import _proxy as _proxy_v1
14:30:24   File "/var/lib/jenkins/tools/0/charm-test-infra/.tox/clients/lib/python3.5/site-packages/openstack/image/v1/_proxy.py", line 51
14:30:24     **image_kwargs,
14:30:24                   ^
14:30:24 SyntaxError: invalid syntax
```

http://osci:8080/job/test_charm_single/119945/console
https://review.opendev.org/c/openstack/charm-ceph-radosgw/+/764641
