### PR TITLE
Revert back to websocket-client from -py3

### DIFF
--- a/py3-clients-requirements.txt
+++ b/py3-clients-requirements.txt
@@ -8,7 +8,7 @@ git+https://github.com/juju/juju-crashdump.git@dba9ff0e6d71d25d37d9011d032d5fcc1
 
 # Mojo
 juju-deployer
-websocket-client-py3!=0.44.0  # https://bugs.launchpad.net/mojo/+bug/1713871
+websocket-client!=0.44.0  # https://bugs.launchpad.net/mojo/+bug/1713871
 argcomplete>=0.8.1  # Version in Xenial
 jinja2>=2.8  # Version in Xenial
 setuptools==36.4.0  # For Mojo


### PR DESCRIPTION
There IS no version of websocket-client-py3 > 0.15 and adding this line
breaks it on xenial (where mojo runs).  The pypi name is
websocket-client regardless of whether it is py3 or py2.