### PR TITLE
Set the default logging to DEBUG for jobs on serverstack

### DIFF
--- a/juju-configs/model-default-serverstack.yaml
+++ b/juju-configs/model-default-serverstack.yaml
@@ -9,3 +9,6 @@ transmit-vendor-metrics: false
 enable-os-upgrade: false
 automatically-retry-hooks: false
 use-default-secgroup: true
+# NOTE(ajkavanagh): juju changed default logging to INFO at 2.8.0 but we need a
+# bit more.  Optionally, we could add ";unit=TRACE" to get even more.
+logging-config: "<root>=DEBUG"


### PR DESCRIPTION
At Juju 2.8.0, juju set the default logging from DEBUG to INFO.  As
such, this misses a lot of important logging (for development) on jobs
on serverstack.  This resets the logging back to DEBUG for serverstack
CI jobs.