### PR TITLE
Add extra steps for Focal/Jammy to address #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,33 +8,56 @@ See also: [OpenStack Charm Guide](https://docs.openstack.org/charm-guide/latest/
 ### Resolving virtualenv build dependencies on a fresh Bionic host
 
 ```
-ubuntu@beisner-bastion:~$ sudo apt install tox python3-dev libffi-dev libssl-dev build-essential bzr
+ubuntu@nuccitheboss-bastion:~$ sudo apt install tox python3-dev libffi-dev libssl-dev build-essential bzr
+ubuntu@nuccitheboss-bastion:~$ sudo snap install juju --classic
 ```
 
+### Resolving virtualenv build dependencies on a fresh Focal/Jammie host
+
+Due to a descrepancy in the `bzr` package between Bionic and Focal/Jammie (see issue #55), there are few extra steps that need to be taken to resolve the virtualenv build dependencies on a fresh Focal/Jammie host.
+
+
+```
+ubuntu@nuccitheboss-bastion:~$ sudo apt install tox python3-dev build-essential wget libffi-dev libssl-dev libbz2-dev libncurses-dev libreadline-dev libsqlite3-dev liblzma-dev zlib1g-dev
+ubuntu@nuccitheboss-bastion:~$ sudo snap install juju --classic
+ubuntu@nuccitheboss-bastion:~$ curl https://pyenv.run | bash
+ubuntu@nuccitheboss-bastion:~$ cat << EOF >> ~/.bashrc
+> export PATH="$HOME/.pyenv/bin:$PATH"
+> eval "$(pyenv init --path)"
+> eval "$(pyenv virtualenv-init -)"
+> EOF
+ubuntu@nuccitheboss-bastion:~$ source ~/.bashrc
+ubuntu@nuccitheboss-bastion:~$ pyenv install 3.10.4
+ubuntu@nuccitheboss-bastion:~$ pyenv install 2.7.15
+ubuntu@nuccitheboss-bastion:~$ pyenv global 3.10.4 2.7.15
+ubuntu@nuccitheboss-bastion:~$ python2 -m pip install paramiko pycrypto
+ubuntu@nuccitheboss-bastion:~$ wget https://launchpad.net/bzr/2.7/2.7.0/+download/bzr-2.7.0.tar.gz -O - | tar -xzf -
+ubuntu@nuccitheboss-bastion:~$ python2 bzr-2.7.0/setup.py install
+ubuntu@nuccitheboss-bastion:~$ export PATH=$HOME/.pyenv/versions/2.7.15/bin:$PATH
+```
+
+*It is ugly, but it gets the job done :)*
 
 ### Clients virtualenv via Tox
 
 ```
-ubuntu@beisner-bastion:~/git/charm-test-infra$ tox
-clients create: /home/ubuntu/git/charm-test-infra/.tox/clients
-clients installdeps: -r/home/ubuntu/git/charm-test-infra/py3-clients-requirements.txt
-clients installed: aodhclient==1.1.0,appdirs==1.4.3,argcomplete==1.9.4,asn1crypto==0.24.0,async-generator==1.9,Babel==2.6.0,bcrypt==3.1.4,certifi==2018.4.16,cffi==1.11.5,chardet==3.0.4,cliff==2.13.0,cmd2==0.9.3,colorama==0.3.9,cryptography==2.3,debtcollector==1.19.0,decorator==4.3.0,deprecation==2.0.5,distro-info==0.0.0,dnspython==1.15.0,dogpile.cache==0.6.6,futures==3.1.1,hvac==0.6.1,idna==2.7,iso8601==0.1.12,Jinja2==2.10,jmespath==0.9.3,jsonpatch==1.23,jsonpointer==2.0,jsonschema==2.6.0,juju==0.9.1,juju-deployer==0.11.0,juju-wait==2.6.4,jujubundlelib==0.5.6,jujuclient==0.54.0,keystoneauth1==3.9.0,macaroonbakery==1.1.3,MarkupSafe==1.0,mojo==0.4.5,monotonic==1.5,msgpack==0.5.6,munch==2.3.2,netaddr==0.7.19,netifaces==0.10.7,openstacksdk==0.16.0,os-client-config==1.31.2,os-service-types==1.2.0,osc-lib==1.11.0,oslo.config==6.3.0,oslo.context==2.21.0,oslo.i18n==3.20.0,oslo.log==3.39.0,oslo.serialization==2.27.0,oslo.utils==3.36.3,packaging==17.1,paramiko==2.4.1,pbr==4.1.0,pkg-resources==0.0.0,prettytable==0.7.2,protobuf==3.6.0,pyasn1==0.4.3,pycparser==2.18,pyinotify==0.9.6,pylxd==2.0.7,pymacaroons==0.13.0,PyNaCl==1.2.1,pyOpenSSL==18.0.0,pyparsing==2.2.0,pyperclip==1.6.2,pyRFC3339==1.1,python-ceilometerclient==2.9.0,python-cinderclient==3.6.1,python-codetree==0.1.6,python-dateutil==2.7.3,python-designateclient==2.9.0,python-glanceclient==2.11.1,python-heatclient==1.16.0,python-keystoneclient==3.17.0,python-neutronclient==6.9.0,python-novaclient==10.3.0,python-openstackclient==3.15.0,python-swiftclient==3.5.0,pytz==2018.5,PyYAML==3.13,requests==2.19.1,requests-unixsocket==0.1.5,requestsexceptions==1.4.0,rfc3986==1.1.0,simplejson==3.16.0,six==1.11.0,stevedore==1.28.0,tenacity==4.12.0,theblues==0.3.8,urllib3==1.23,warlock==1.3.0,wcwidth==0.1.7,websocket-client==0.48.0,websockets==6.0,wrapt==1.10.11,ws4py==0.5.1,zaza==0.0.2.dev1
-clients runtests: PYTHONHASHSEED='0'
-clients runtests: commands[0] | mojo --version
+ubuntu@nuccitheboss-bastion:~/charm-test-infra$ tox
+clients create: /home/ubuntu/charm-test-infra/.tox/clients
+clients installdeps: -r/home/ubuntu/charm-test-infra/py3-clients-requirements.txt
+clients installed: aiohttp==3.8.1,aiosignal==1.2.0,aodhclient==2.4.1,appdirs==1.4.4,argcomplete==2.0.0,async-generator==1.10,async-timeout==4.0.2,attrs==21.4.0,autopage==0.5.1,Babel==2.10.1,bcrypt==3.2.2,boto3==1.24.7,botocore==1.27.7,cachetools==5.2.0,certifi==2022.5.18.1,cffi==1.15.0,charset-normalizer==2.0.12,cliff==3.10.1,cmd2==2.4.1,colorclass==2.2.2,cryptography==3.3.2,debtcollector==2.5.0,decorator==5.1.1,dnspython==2.2.1,dogpile.cache==1.1.6,fasteners==0.17.3,frozenlist==1.3.0,futurist==1.10.0,gnocchiclient==7.0.7,google-auth==2.7.0,hvac==0.6.4,idna==3.3,importlib-resources==5.7.1,iso8601==1.0.2,Jinja2==3.1.2,jmespath==1.0.0,jsonpatch==1.32,jsonpointer==2.3,jsonschema==4.6.0,juju==2.9.10,juju-deployer==0.11.0,juju-wait==2.8.4,jujubundlelib==0.5.7,jujuclient==0.54.0,jujucrashdump==0.0.0,keystoneauth1==4.6.0,kubernetes==23.6.0,lxml==4.9.0,macaroonbakery==1.3.1,MarkupSafe==2.1.1,mojo==0.4.5,monotonic==1.6,msgpack==1.0.4,multidict==6.0.2,munch==2.5.0,mypy-extensions==0.4.3,netaddr==0.8.0,netifaces==0.11.0,oauthlib==3.2.0,openstacksdk==0.99.0,os-client-config==2.1.0,os-service-types==1.7.0,osc-lib==2.6.0,oslo.concurrency==4.5.1,oslo.config==6.11.3,oslo.context==4.1.0,oslo.i18n==5.1.0,oslo.log==5.0.0,oslo.serialization==4.3.0,oslo.utils==4.13.0,osprofiler==3.4.3,packaging==21.3,paramiko==2.11.0,pbr==5.9.0,pika==1.2.1,prettytable==0.7.2,protobuf==3.20.1,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycparser==2.21,pyinotify==0.9.6,pylxd==2.0.7,pymacaroons==0.13.0,pymongo==4.1.1,PyNaCl==1.5.0,pyOpenSSL==22.0.0,pyparsing==2.4.7,pyperclip==1.8.2,pyRFC3339==1.1,pyrsistent==0.18.1,python-barbicanclient==5.3.0,python-ceilometerclient==2.9.0,python-cinderclient==8.3.0,python-codetree==1.2.1,python-dateutil==2.8.2,python-designateclient==4.5.0,python-glanceclient==4.0.0,python-heatclient==2.5.1,python-ironicclient==4.11.0,python-keystoneclient==4.5.0,python-libmaas==0.6.6,python-manilaclient==1.29.0,python-neutronclient==7.8.0,python-novaclient==18.0.0,python-octaviaclient==1.10.1,python-openstackclient==5.8.0,python-swiftclient==4.0.0,pytz==2022.1,PyYAML==6.0,requests==2.28.0,requests-oauthlib==1.3.1,requests-unixsocket==0.3.0,requestsexceptions==1.4.0,rfc3986==2.0.0,rsa==4.8,s3transfer==0.6.0,simplejson==3.17.6,six==1.16.0,stevedore==3.5.0,tenacity==8.0.1,terminaltables==3.1.10,theblues==0.5.2,toposort==1.7,typing-extensions==4.2.0,typing-inspect==0.7.1,ujson==5.3.0,urllib3==1.26.9,warlock==1.3.3,wcwidth==0.2.5,WebOb==1.8.7,websocket-client==1.3.2,websockets==7.0,wrapt==1.14.1,ws4py==0.5.1,yarl==1.7.2,zaza==0.0.2.dev1,zaza.openstack==0.0.1.dev1,zipp==3.8.0
+clients run-test-pre: PYTHONHASHSEED='0'
+clients run-test: commands[0] | mojo --version
 0.4.5
-clients runtests: commands[1] | openstack --version
-openstack 3.15.0
-________________________________________________________________________________________ summary ________________________________________________________________________________________
+clients run-test: commands[1] | openstack --version
+openstack 5.8.0
+_____________________________________________________________________________________________________ summary _____________________________________________________________________________________________________
   clients: commands succeeded
   congratulations :)
-ubuntu@beisner-bastion:~/git/charm-test-infra$
-
-
-ubuntu@beisner-bastion:~/git/charm-test-infra$ . clientsrc
-(clients) ubuntu@beisner-bastion:~/git/charm-test-infra$ openstack --version
-openstack 3.15.0
-(clients) ubuntu@beisner-bastion:~/git/charm-test-infra$ mojo --version
+ubuntu@nuccitheboss-bastion:~/charm-test-infra$ . clientsrc 
+(clients) ubuntu@nuccitheboss-bastion:~/charm-test-infra$ openstack --version
+openstack 5.8.0
+(clients) ubuntu@nuccitheboss-bastion:~/charm-test-infra$ mojo --version
 0.4.5
-(clients) ubuntu@beisner-bastion:~/git/charm-test-infra$ deactivate
-ubuntu@beisner-bastion:~/git/charm-test-infra$
+(clients) ubuntu@nuccitheboss-bastion:~/charm-test-infra$ deactivate
+ubuntu@nuccitheboss-bastion:~/charm-test-infra$
 ```


### PR DESCRIPTION
## What I initially tried
After I discovered that the issue was a difference in the `bzr` package between Ubuntu versions, I tried to build a `bzr-legacy` Debian package for Focal and Jammy that I could host in a PPA on Launchpad. However, I got hung up because many of the build dependencies are no longer available in the Ubuntu package archives (joys of working with older software). `debmake` worked nicely for me, but `debuild` refused to make the package due to the missing dependencies.

## Solution
I decided to use `pyenv` to install Python 3.10.4 and 2.7.15 side-by-side, install `paramiko` and `pycrypto` into 2.7.15, download the Bazaar source code from Launchpad, and then install Bazaar manually.

## Next steps/future work
Current solution is rather ugly (lots of steps involved), so in the future I would like to trim it down a bit. Unfortunately, without setting up a whole dedicated legacy PPA to GNU Bazaar (not Breezy), we probably will not be able to build a Debian package to provide Bazaar.

To circumvent this issue without needing `pyenv` or a legacy Debian package, we will need to deal with these two problem children in `py3-clients-requirements.txt` to avoid the `AttributeError` mentioned in #55:
```
bzr+lp:codetree#egg=python-codetree  # <= Problem child 1

# disabled because of a bug because of which whitelisted states aren't taken
# into account when waiting for the model to become ready:
# bzr+lp:mojo#egg=mojo
bzr+lp:~ost-maintainers/mojo/py3#egg=mojo  # <= Problem child 2
```